### PR TITLE
Simplify and support IE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4607,7 +4607,8 @@
     "macaddress": {
       "version": "0.2.8",
       "resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
-      "integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI="
+      "integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI=",
+      "dev": true
     },
     "make-dir": {
       "version": "1.0.0",
@@ -6999,6 +7000,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
       "integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
+      "dev": true,
       "requires": {
         "macaddress": "0.2.8"
       }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "webpack-merge": "^4.1.0"
   },
   "dependencies": {
-    "core-js": "^2.5.3",
-    "uniqid": "^4.1.1"
+    "core-js": "^2.5.3"
   }
 }

--- a/src/Drag.vue
+++ b/src/Drag.vue
@@ -16,11 +16,8 @@
 </template>
 
 <script>
-	import uniqid from 'uniqid';
-	import { transferDataStore } from './stores';
-	import {
-		dropEffects, effectsAllowed, events, mimeType, smuggleKeyMimeType,
-	} from './constants';
+	import transferDataStore from './transferDataStore';
+	import { dropEffects, effectsAllowed, events } from './constants';
 
 	export default {
 		props: {
@@ -35,7 +32,7 @@
 			tag: { type: String, default: 'div' },
 		},
 		data() {
-			return { id: uniqid(), dragging: false };
+			return { dragging: false };
 		},
 		computed: {
 			events: () => events,
@@ -78,9 +75,7 @@
 
 					// Set the transfer data
 					if (this.transferData !== undefined) {
-						this.$set(transferDataStore, this.id, this.transferData);
-						transfer.setData(mimeType, this.id);
-						transfer.setData(`${smuggleKeyMimeType}${this.id}`, this.id);
+						transferDataStore.data = this.transferData;
 					}
 
 					// Indicate that we're dragging.
@@ -92,7 +87,7 @@
 
 				// Clean up stored data on drag end after emitting.
 				if (name === events.dragend) {
-					this.$delete(transferDataStore, this.id);
+					transferDataStore.data = undefined;
 					this.dragging = false;
 				}
 			},

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,8 +1,5 @@
 const keyMirror = keys => keys.reduce((acc, k) => (acc[k] = k) && acc, {});
 
-export const mimeType = 'text/x-vue-drag-drop-key';
-export const mimeDelimiter = ':';
-export const smuggleKeyMimeType = `${mimeType}${mimeDelimiter}`;
 export const events = keyMirror([
 	'drag', 'dragend',  'dragenter', 'dragleave', 'dragstart', 'dragover', 'drop',
 ]);

--- a/src/stores.js
+++ b/src/stores.js
@@ -1,1 +1,0 @@
-export const transferDataStore = {};

--- a/src/transferDataStore.js
+++ b/src/transferDataStore.js
@@ -1,0 +1,1 @@
+export default { data: undefined };


### PR DESCRIPTION
This greatly simplifies the way we manage transfer data. Instead of smuggling a unique key in the mimetype of the event's `transferData`, we're setting a single key on a globally available object, and overwriting it with each drag interaction. As a result, we're not even using the native `transferData` object at all, so IE compatibility is no longer a concern.

I'm not sure if this is going to screw anything up. The only scenario I can imagine it being a problem is if there are somehow multiple drag actions in progress at the same time. Maybe in some kind of multitouch scenario? I don't know, it seems unlikely to be a problem.