### PR TITLE
Stop event propagation when starting drag in order to support nested drag elements

### DIFF
--- a/src/Drag.vue
+++ b/src/Drag.vue
@@ -86,6 +86,11 @@
 
 					// Indicate that we're dragging.
 					this.dragging = true;
+					
+					// Stop propagation of this event. In case we have nested drag components, 
+					// we only want to drag the innermost dragged component, not start multiple
+					// drags at once (which isn't possible anyway)
+					nativeEvent.stopPropagation();
 				}
 
 				// At last, emit the event.


### PR DESCRIPTION
Stop propagation of this event. In case we have nested drag components, we only want to drag the innermost dragged component, not start multiple drags at once (which isn't possible anyway)